### PR TITLE
Allow this package to be pip installable without edit mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='gym_minigrid',
     version='0.0.1',
     keywords='memory, environment, agent, rl, openaigym, openai-gym, gym',
+    packages=['gym_minigrid'],
     install_requires=[
         'gym>=0.9.0',
         'numpy>=1.10.0',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='gym_minigrid',
     version='0.0.1',
     keywords='memory, environment, agent, rl, openaigym, openai-gym, gym',
-    packages=['gym_minigrid'],
+    packages=['gym_minigrid', 'gym_minigrid.envs'],
     install_requires=[
         'gym>=0.9.0',
         'numpy>=1.10.0',


### PR DESCRIPTION
With this change, this package can now be installed via: `pip3 install git+https://github.com/maximecb/gym-minigrid.git` which also makes it easier to include in some other packages requirements.txt or similar environment set up process.