### PR TITLE
Increase max_steps in DoorKey to make it learnable

### DIFF
--- a/gym_minigrid/envs/doorkey.py
+++ b/gym_minigrid/envs/doorkey.py
@@ -9,7 +9,7 @@ class DoorKeyEnv(MiniGridEnv):
     def __init__(self, size=8):
         super().__init__(
             grid_size=size,
-            max_steps=4*size*size
+            max_steps=10*size*size
         )
 
     def _gen_grid(self, width, height):


### PR DESCRIPTION
During my internship, I trained on DoorKey with a higher max-step because it was impossible to learn with the current one. I forgot to do a PR at this moment.