### PR TITLE
Does a grid contain an object without color

### DIFF
--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -375,6 +375,8 @@ class Grid:
                     continue
                 if (e.color, e.type) == key:
                     return True
+                if key[0] is None and key[1] == e.type:
+                    return True
         return False
 
     def __eq__(self, other):


### PR DESCRIPTION
Allow checking if a grid contains an object defined by a pair (None, object name). Useful if the mission gives instructions about an object without specifying its color