### PR TITLE
Allow Grid.rotate_left() for rectangular grids

### DIFF
--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -469,12 +469,12 @@ class Grid:
         Rotate the grid to the left (counter-clockwise)
         """
 
-        grid = Grid(self.width, self.height)
+        grid = Grid(self.height, self.width)
 
-        for j in range(0, self.height):
-            for i in range(0, self.width):
-                v = self.get(self.width - 1 - j, i)
-                grid.set(i, j, v)
+        for i in range(self.width):
+            for j in range(self.height):
+                v = self.get(i, j)
+                grid.set(j, grid.height - 1 - i, v)
 
         return grid
 


### PR DESCRIPTION
In upstream, Grid.rotate_left only works for square grids.  This minor PR fixes the method for non-square ones.

```
from gym_minigrid.minigrid import Grid, Lava

grid = Grid(4, 5)
grid.set(0, 1, Lava())
print(grid.encode().T)

grid = grid.rotate_left()  # throws exception in upstream code;
print(grid.encode().T)
```