### PR TITLE
Fix sneaky view-limit bug in Grid.process_vis()

### DIFF
--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -631,7 +631,7 @@ class Grid:
 
         mask[agent_pos[0], agent_pos[1]] = True
 
-        for j in reversed(range(1, grid.height)):
+        for j in reversed(range(0, grid.height)):
             for i in range(0, grid.width-1):
                 if not mask[i, j]:
                     continue
@@ -641,8 +641,9 @@ class Grid:
                     continue
 
                 mask[i+1, j] = True
-                mask[i+1, j-1] = True
-                mask[i, j-1] = True
+                if j > 0:
+                    mask[i+1, j-1] = True
+                    mask[i, j-1] = True
 
             for i in reversed(range(1, grid.width)):
                 if not mask[i, j]:
@@ -652,9 +653,10 @@ class Grid:
                 if cell and not cell.see_behind():
                     continue
 
-                mask[i-1, j-1] = True
                 mask[i-1, j] = True
-                mask[i, j-1] = True
+                if j > 0:
+                    mask[i-1, j-1] = True
+                    mask[i, j-1] = True
 
         for j in range(0, grid.height):
             for i in range(0, grid.width):


### PR DESCRIPTION
There is a subtle bug in Grid.process_vis();  I noticed it when running the MiniGrid-MemoryS11-v0 environment in manual control.

If I position myself such that my view barely reaches the end of the corridor...

![minigrid gym environment_009](https://user-images.githubusercontent.com/1794938/48522301-29b6ca00-e846-11e8-9550-6e460c330884.png)

... and then take one step forward, I expect to be able to see 7 cells in the vertical corridor to the right.  Instead, the view is limited as follows:

![minigrid gym environment_010](https://user-images.githubusercontent.com/1794938/48522311-32a79b80-e846-11e8-9595-7244e9316836.png)

The current implementation does not extend the viewing area in the row/column furthest away from the agent in a way which is consistent with the areas closer to the agent.  I assume this to be a bug?

This PR fixes indexing issues in Grid.process_vis(), which results in the (supposedly) correct viewing mask:

![minigrid gym environment_011](https://user-images.githubusercontent.com/1794938/48522319-376c4f80-e846-11e8-8cc2-1942be590ef3.png)
