### PR TITLE
make observation image have different values for empty and unseen cells (#35)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ import random
 import numpy as np
 import gym
 from gym_minigrid.register import env_list
-from gym_minigrid.minigrid import Grid
+from gym_minigrid.minigrid import Grid, OBJECT_TO_IDX
 
 # Test specifically importing a specific environment
 from gym_minigrid.envs import DoorKeyEnv
@@ -50,8 +50,8 @@ for envName in env_list:
 
         # Test observation encode/decode roundtrip
         img = obs['image']
-        grid = Grid.decode(img)
-        img2 = grid.encode()
+        vis_mask = img[:, :, 0] != OBJECT_TO_IDX['unseen']  # hackish
+        img2 = Grid.decode(img).encode(vis_mask=vis_mask)
         assert np.array_equal(img, img2)
 
         # Check that the reward is within the specified range


### PR DESCRIPTION
 * add ('unseen', 0) to `OBJECT_TO_IDX` dictionary;  all other values are
 shifted up by 1 to make space for the new value.

 * update `Grid.encode` to take an optional `vis_mask` argument, and
 return an image which now distinguishes between unseen and empty cells
 (values respectively 0 and 1).

 * update `Grid.decode` to handle the above changes;  values 0 and 1 in
 input array are both mapped to None in output grid.

 * make `Grid.decode` a static method;  it was already used as a static
 method but was missing the appropriate decorator.

 * update "observation encode/decode roundtrip" test in run_tests.py;
 the visualization mask necessary to perform the test is found by
 manually checking the first channel of the image for value 0.