### PR TITLE
Wrapper Improvements

### DIFF
--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -15,27 +15,26 @@ class ActionBonus(gym.core.Wrapper):
     """
 
     def __init__(self, env):
+        self.__dict__.update(vars(env))  # Pass values to super wrapper
         super().__init__(env)
         self.counts = {}
 
     def step(self, action):
-
         obs, reward, done, info = self.env.step(action)
 
         env = self.unwrapped
-        tup = (env.agentPos, env.agentDir, action)
+        tup = (tuple(env.agent_pos), env.agent_dir, action)
 
         # Get the count for this (s,a) pair
-        preCnt = 0
+        pre_count = 0
         if tup in self.counts:
-            preCnt = self.counts[tup]
+            pre_count = self.counts[tup]
 
         # Update the count for this (s,a) pair
-        newCnt = preCnt + 1
-        self.counts[tup] = newCnt
+        new_count = pre_count + 1
+        self.counts[tup] = new_count
 
-        bonus = 1 / math.sqrt(newCnt)
-
+        bonus = 1 / math.sqrt(new_count)
         reward += bonus
 
         return obs, reward, done, info
@@ -47,29 +46,28 @@ class StateBonus(gym.core.Wrapper):
     """
 
     def __init__(self, env):
+        self.__dict__.update(vars(env))  # Pass values to super wrapper
         super().__init__(env)
         self.counts = {}
 
     def step(self, action):
-
         obs, reward, done, info = self.env.step(action)
 
         # Tuple based on which we index the counts
         # We use the position after an update
         env = self.unwrapped
-        tup = (env.agentPos)
+        tup = (tuple(env.agent_pos))
 
         # Get the count for this key
-        preCnt = 0
+        pre_count = 0
         if tup in self.counts:
-            preCnt = self.counts[tup]
+            pre_count = self.counts[tup]
 
         # Update the count for this key
-        newCnt = preCnt + 1
-        self.counts[tup] = newCnt
+        new_count = pre_count + 1
+        self.counts[tup] = new_count
 
-        bonus = 1 / math.sqrt(newCnt)
-
+        bonus = 1 / math.sqrt(new_count)
         reward += bonus
 
         return obs, reward, done, info
@@ -80,8 +78,7 @@ class ImgObsWrapper(gym.core.ObservationWrapper):
     """
 
     def __init__(self, env):
-        # Hack to pass values to super wrapper
-        self.__dict__.update(vars(env))
+        self.__dict__.update(vars(env))  # Pass values to super wrapper
         super().__init__(env)
 
         self.observation_space = env.observation_space.spaces['image']
@@ -95,7 +92,7 @@ class FullyObsWrapper(gym.core.ObservationWrapper):
     """
 
     def __init__(self, env):
-        self.__dict__.update(vars(env))  # hack to pass values to super wrapper
+        self.__dict__.update(vars(env))  # Pass values to super wrapper
         super().__init__(env)
 
         self.observation_space = spaces.Box(
@@ -117,6 +114,7 @@ class FlatObsWrapper(gym.core.ObservationWrapper):
     """
 
     def __init__(self, env, maxStrLen=64):
+        self.__dict__.update(vars(env))  # Pass values to super wrapper
         super().__init__(env)
 
         self.maxStrLen = maxStrLen
@@ -168,7 +166,7 @@ class AgentViewWrapper(gym.core.Wrapper):
     """
 
     def __init__(self, env, agent_view_size=7, agent_view_centered=False):
-        self.__dict__.update(vars(env))  # Hack to pass values to super wrapper
+        self.__dict__.update(vars(env))  # Pass values to super wrapper
         super(AgentViewWrapper, self).__init__(env)
 
         # Override default arguments

--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -80,9 +80,10 @@ class ImgObsWrapper(gym.core.ObservationWrapper):
     """
 
     def __init__(self, env):
-        super().__init__(env)
         # Hack to pass values to super wrapper
         self.__dict__.update(vars(env))
+        super().__init__(env)
+
         self.observation_space = env.observation_space.spaces['image']
 
     def observation(self, obs):
@@ -94,8 +95,9 @@ class FullyObsWrapper(gym.core.ObservationWrapper):
     """
 
     def __init__(self, env):
-        super().__init__(env)
         self.__dict__.update(vars(env))  # hack to pass values to super wrapper
+        super().__init__(env)
+
         self.observation_space = spaces.Box(
             low=0,
             high=255,
@@ -165,12 +167,13 @@ class AgentViewWrapper(gym.core.Wrapper):
     Wrapper to customize the agent's field of view.
     """
 
-    def __init__(self, env, agent_view_size=7):
-        super(AgentViewWrapper, self).__init__(env)
+    def __init__(self, env, agent_view_size=7, agent_view_centered=False):
         self.__dict__.update(vars(env))  # Hack to pass values to super wrapper
+        super(AgentViewWrapper, self).__init__(env)
 
-        # Override default view size
+        # Override default arguments
         env.agent_view_size = agent_view_size
+        env.agent_view_centered = agent_view_centered
 
         # Compute observation space with specified view size
         observation_space = gym.spaces.Box(

--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -39,6 +39,9 @@ class ActionBonus(gym.core.Wrapper):
 
         return obs, reward, done, info
 
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
+
 class StateBonus(gym.core.Wrapper):
     """
     Adds an exploration bonus based on which positions
@@ -71,6 +74,9 @@ class StateBonus(gym.core.Wrapper):
         reward += bonus
 
         return obs, reward, done, info
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
 
 class ImgObsWrapper(gym.core.ObservationWrapper):
     """
@@ -185,3 +191,9 @@ class AgentViewWrapper(gym.core.Wrapper):
         self.observation_space = spaces.Dict({
             'image': observation_space
         })
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
+
+    def step(self, action):
+        return self.env.step(action)

--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -109,8 +109,9 @@ class FullyObsWrapper(gym.core.ObservationWrapper):
         )
 
     def observation(self, obs):
-        full_grid = self.env.grid.encode()
-        full_grid[self.env.agent_pos[0]][self.env.agent_pos[1]] = np.array([255, self.env.agent_dir, 0])
+        env = self.unwrapped
+        full_grid = env.grid.encode()
+        full_grid[env.agent_pos[0]][env.agent_pos[1]] = np.array([255, env.agent_dir, 0])
         return full_grid
 
 class FlatObsWrapper(gym.core.ObservationWrapper):

--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -172,13 +172,12 @@ class AgentViewWrapper(gym.core.Wrapper):
     Wrapper to customize the agent's field of view.
     """
 
-    def __init__(self, env, agent_view_size=7, agent_view_centered=False):
+    def __init__(self, env, agent_view_size=7):
         self.__dict__.update(vars(env))  # Pass values to super wrapper
         super(AgentViewWrapper, self).__init__(env)
 
-        # Override default arguments
-        env.agent_view_size = agent_view_size
-        env.agent_view_centered = agent_view_centered
+        # Override default view size
+        env.unwrapped.agent_view_size = agent_view_size
 
         # Compute observation space with specified view size
         observation_space = gym.spaces.Box(


### PR DESCRIPTION
- Fixed deprecation warnings for `step()` and `reset()` in wrappers that extend the core wrapper. See: https://github.com/openai/gym/blob/master/gym/core.py#L223 for the source of the deprecation warnings
- Fixed State & Action Bonus wrappers. They were broken due to:
   - Incorrect/outdated reference to `agentPos` and `agentDir`, which don't exist
   - The agent pos can be a numpy array and could not be stored in this format, converted it to tuple
- Ensured that the previous env (wrapped or unwrapped) values get passed to the current wrapper using the same method as other wrappers
- Modified FullyObsWrapper and AgentViewWrapper to utilise `self.unwrapped` as they didn't work well with wrapped environments, e.g. FullyObsWrapper had an identical grid for each timestep (as the `agent_pos` it referred to was not changing)