### PR TITLE
Fixed placing key/box in same position with blocking_ball.

### DIFF
--- a/gym_minigrid/envs/obstructedmaze.py
+++ b/gym_minigrid/envs/obstructedmaze.py
@@ -58,6 +58,11 @@ class ObstructedMazeEnv(RoomGrid):
 
         door, door_pos = super().add_door(i, j, door_idx, color, locked=locked)
 
+        if blocked:
+            vec = DIR_TO_VEC[door_idx]
+            blocking_ball = Ball(self.blocking_ball_color) if blocked else None
+            self.grid.set(door_pos[0]-vec[0], door_pos[1]-vec[1], blocking_ball)
+            
         if locked:
             obj = Key(door.color)
             if key_in_box:
@@ -65,10 +70,6 @@ class ObstructedMazeEnv(RoomGrid):
                 box.contains = obj
                 obj = box
             self.place_in_room(i, j, obj)
-        if blocked:
-            vec = DIR_TO_VEC[door_idx]
-            blocking_ball = Ball(self.blocking_ball_color) if blocked else None
-            self.grid.set(door_pos[0]-vec[0], door_pos[1]-vec[1], blocking_ball)
 
         return door, door_pos
 


### PR DESCRIPTION
Bug in **ObstructedMazeEnv** when adding blocking ball with the same position of the key (/box). Solution add blocking ball and then place key on remaining empty positions.