### PR TITLE
Avoid agent in place_obj method after game start and fix Dynamic-Obstacles bugs

### DIFF
--- a/gym_minigrid/envs/dynamicobstacles.py
+++ b/gym_minigrid/envs/dynamicobstacles.py
@@ -2,6 +2,19 @@ from gym_minigrid.minigrid import *
 from gym_minigrid.register import register
 from operator import add
 
+
+class NoPickUpBall(WorldObj):
+    def __init__(self, color='blue'):
+        super(NoPickUpBall, self).__init__('ball', color)
+
+    def can_pickup(self):
+        return False
+
+    def render(self, r):
+        self._set_color(r)
+        r.drawCircle(CELL_PIXELS * 0.5, CELL_PIXELS * 0.5, 10)
+
+
 class DynamicObstaclesEnv(MiniGridEnv):
     """
     Single-room square grid environment with moving obstacles
@@ -55,7 +68,7 @@ class DynamicObstaclesEnv(MiniGridEnv):
         if self.show_obstacles:
             self.obstacles = []
             for i_obst in range(self.n_obstacles):
-                self.obstacles.append(Ball())
+                self.obstacles.append(NoPickUpBall())
                 self.place_obj(self.obstacles[i_obst], max_tries=100)
         self.mission = "get to the green goal square"
 

--- a/gym_minigrid/envs/dynamicobstacles.py
+++ b/gym_minigrid/envs/dynamicobstacles.py
@@ -85,7 +85,8 @@ class DynamicObstaclesEnv(MiniGridEnv):
                 old_pos = self.obstacles[i_obst].cur_pos
                 top = tuple(map(add, old_pos, (-1, -1)))
                 self.grid.set(*old_pos, None)
-                self.place_obj(self.obstacles[i_obst], top=top, size=(3,3), max_tries=100)
+                self.place_obj(self.obstacles[i_obst], top=top, size=(3,3), max_tries=100,
+                               avoid_agent=False)
                 if np.array_equal(self.obstacles[i_obst].cur_pos, self.agent_pos):
                     reward = -1
                     done = True

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -923,8 +923,8 @@ class MiniGridEnv(gym.Env):
             num_tries += 1
 
             pos = np.array((
-                self._rand_int(top[0], top[0] + size[0]),
-                self._rand_int(top[1], top[1] + size[1])
+                self._rand_int(top[0], min(top[0] + size[0], self.grid.width)),
+                self._rand_int(top[1], min(top[1] + size[1], self.grid.height))
             ))
 
             # Don't place the object on top of another object

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -908,6 +908,8 @@ class MiniGridEnv(gym.Env):
 
         if top is None:
             top = (0, 0)
+        else:
+            top = (max(top[0], 0), max(top[1], 0))
 
         if size is None:
             size = (self.grid.width, self.grid.height)


### PR DESCRIPTION
Fixed avoiding agent when placing object after game start. Had to consider _start_pos_ as well because some environments placed objects depending on this variable only (before _agent_pos_ was set). Toggle in _place_obj_ - _start_pos_ / _agent_pos_ while generating grid, based on _is_gen_grid_ variable.

_Dynamic-Obstacles_ env was relying on being able to position obstacle on top of the agent, so I extended _place_obj_ method to be able to this is as well.  

Closes: #66

Found what I guess to be an unintentional _bug in Dynamic-Obstacles_: being able to pick up the obstacles. This was causing also an error because of _self.obstacles_ list not being updated. Fixed this by changing to a ball that cannot be picked up.

[Fix 837f5e5](https://github.com/maximecb/gym-minigrid/commit/837f5e5e32a0f8d878cab313fdd98f795f81723e)

