### PR TITLE
Fix type of observation_space for wrappers.

### DIFF
--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -127,12 +127,12 @@ class OneHotPartialObsWrapper(gym.core.ObservationWrapper):
 
         num_bits = len(OBJECT_TO_IDX) + len(COLOR_TO_IDX) + len(STATE_TO_IDX)
 
-        self.observation_space = spaces.Box(
-            low=0,
-            high=255,
-            shape=(obs_shape[0], obs_shape[1], num_bits),
-            dtype='uint8'
-        )
+        self.observation_space.spaces["image"] = spaces.Box(
+                low=0,
+                high=255,
+                shape=(obs_shape[0], obs_shape[1], num_bits),
+                dtype='uint8'
+            )
 
     def observation(self, obs):
         img = obs['image']
@@ -165,7 +165,7 @@ class RGBImgObsWrapper(gym.core.ObservationWrapper):
 
         self.tile_size = tile_size
 
-        self.observation_space = spaces.Box(
+        self.observation_space.spaces['image'] = spaces.Box(
             low=0,
             high=255,
             shape=(self.env.width*tile_size, self.env.height*tile_size, 3),
@@ -192,7 +192,7 @@ class RGBImgPartialObsWrapper(gym.core.ObservationWrapper):
         self.tile_size = tile_size
 
         obs_shape = env.observation_space['image'].shape
-        self.observation_space = spaces.Box(
+        self.observation_space.spaces['image'] = spaces.Box(
             low=0,
             high=255,
             shape=(obs_shape[0] * tile_size, obs_shape[1] * tile_size, 3),

--- a/run_tests.py
+++ b/run_tests.py
@@ -112,8 +112,10 @@ for env_name in env_list:
     for wrapper in wrappers:
         env = wrapper(gym.make(env_name))
         obs_space, wrapper_name = env.observation_space, wrapper.__name__
-        assert isinstance(obs_space, spaces.Dict), (
-            f"Observation space for {wrapper_name} is not a Dict: {obs_space}."
+        assert isinstance(
+            obs_space, spaces.Dict
+        ), "Observation space for {0} is not a Dict: {1}.".format(
+            wrapper_name, obs_space
         )
         # this shuld not fail either
         ImgObsWrapper(env)

--- a/run_tests.py
+++ b/run_tests.py
@@ -103,6 +103,21 @@ for env_name in env_list:
     env.step(0)
     env.close()
 
+    # Test the wrappers return proper observation spaces.
+    wrappers = [
+        RGBImgObsWrapper,
+        RGBImgPartialObsWrapper,
+        OneHotPartialObsWrapper
+    ]
+    for wrapper in wrappers:
+        env = wrapper(gym.make(env_name))
+        obs_space, wrapper_name = env.observation_space, wrapper.__name__
+        assert isinstance(obs_space, spaces.Dict), (
+            f"Observation space for {wrapper_name} is not a Dict: {obs_space}."
+        )
+        # this shuld not fail either
+        ImgObsWrapper(env)
+
 ##############################################################################
 
 print('testing agent_sees method')


### PR DESCRIPTION
Wrappers changing the observation space need to set `gym.spaces.Dict` types for the `env.observation_space` attribute. This also fixes situations in which you would want to receive only the RGB view of the agent, like this: `ImgObsWrapper(RGBImgPartialObsWrapper(env))`.