### PR TITLE
allow passing kwargs to EmptyEnvNxN

### DIFF
--- a/gym_minigrid/envs/empty.py
+++ b/gym_minigrid/envs/empty.py
@@ -42,24 +42,24 @@ class EmptyEnv(MiniGridEnv):
         self.mission = "get to the green goal square"
 
 class EmptyEnv5x5(EmptyEnv):
-    def __init__(self):
-        super().__init__(size=5)
+    def __init__(self, **kwargs):
+        super().__init__(size=5, **kwargs)
 
 class EmptyRandomEnv5x5(EmptyEnv):
     def __init__(self):
         super().__init__(size=5, agent_start_pos=None)
 
 class EmptyEnv6x6(EmptyEnv):
-    def __init__(self):
-        super().__init__(size=6)
+    def __init__(self, **kwargs):
+        super().__init__(size=6, **kwargs)
 
 class EmptyRandomEnv6x6(EmptyEnv):
     def __init__(self):
         super().__init__(size=6, agent_start_pos=None)
 
 class EmptyEnv16x16(EmptyEnv):
-    def __init__(self):
-        super().__init__(size=16)
+    def __init__(self, **kwargs):
+        super().__init__(size=16, **kwargs)
 
 register(
     id='MiniGrid-Empty-5x5-v0',


### PR DESCRIPTION
Hello, a quick change that allows (for example)
`gym.make('MiniGrid-Empty-16x16-v0', agent_start_pos=(7, 7), agent_start_dir=2)`

instead of
`gym.make('MiniGrid-Empty-8x8-v0', size=16, agent_start_pos=(7, 7), agent_start_dir=2)`