### PR TITLE
Fix mistyped variable name obj_type in WoldObj.decode method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ trained_models
 # PyPI
 build/*
 dist/*
+.idea/

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -142,7 +142,7 @@ class WorldObj:
         elif obj_type == 'lava':
             v = Lava()
         else:
-            assert False, "unknown object type in decode '%s'" % objType
+            assert False, "unknown object type in decode '%s'" % obj_type
 
         return v
 


### PR DESCRIPTION
Hey! It looks like a simple typo and not very crucial (at least you will see the effect when something is already wrong), but still here's the fix.

Also, I added `.idea` folder to .gitignore if you don't mind. Otherwise, I will remove it.
This's PyCharm project-specific working folder. I would suggested to add some other common python/ML working folders too, e.g. `.ipynb_checkpoints`. But if you haven't done it yet, then I assume you did it on purpose.

Btw, thanks for the great repo! :)