### PR TITLE
Fix agent's view rectangle calculation (#96), pass kwargs through EmptyEnv

### DIFF
--- a/gym_minigrid/envs/empty.py
+++ b/gym_minigrid/envs/empty.py
@@ -11,6 +11,7 @@ class EmptyEnv(MiniGridEnv):
         size=8,
         agent_start_pos=(1,1),
         agent_start_dir=0,
+        **kwargs
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -19,7 +20,8 @@ class EmptyEnv(MiniGridEnv):
             grid_size=size,
             max_steps=4*size*size,
             # Set this to True for maximum speed
-            see_through_walls=True
+            see_through_walls=True,
+            **kwargs
         )
 
     def _gen_grid(self, width, height):


### PR DESCRIPTION
This PR consists of 2 things:

- fix for #96 
- pass `**kwargs` from `EmptyEnv.__init__` to `MiniGridEnv`

The rationale for the the latter is that we already have passing `**kwargs` from particular implementations `EmptyEnvNxN`. But these `kwargs` only affect `EmptyEnv.__init__`'s arguments - they aren't passed further to `MiniGridEnv`.

I think passing them further seems logical and useful - e.g. it allows direct `agent_view_size` setting instead of using wrapper.