### PR TITLE
Update occlusion logic in process_vis

### DIFF
--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -582,7 +582,7 @@ class Grid:
         mask[agent_pos[0], agent_pos[1]] = True
 
         for j in reversed(range(0, grid.height)):
-            for i in range(0, grid.width-1):
+            for i in range(agent_pos[0], grid.width):
                 if not mask[i, j]:
                     continue
 
@@ -590,12 +590,14 @@ class Grid:
                 if cell and not cell.see_behind():
                     continue
 
-                mask[i+1, j] = True
+                if i < grid.width - 1:
+                    mask[i + 1, j] = True
                 if j > 0:
-                    mask[i+1, j-1] = True
-                    mask[i, j-1] = True
+                    mask[i, j - 1] = True
+                    if i < grid.width - 1:
+                        mask[i + 1, j - 1] = True
 
-            for i in reversed(range(1, grid.width)):
+            for i in reversed(range(0, agent_pos[0]+1)):
                 if not mask[i, j]:
                     continue
 
@@ -603,16 +605,18 @@ class Grid:
                 if cell and not cell.see_behind():
                     continue
 
-                mask[i-1, j] = True
+                if i > 0:
+                    mask[i - 1, j] = True
                 if j > 0:
-                    mask[i-1, j-1] = True
-                    mask[i, j-1] = True
+                    mask[i, j - 1] = True
+                    if i > 0:
+                        mask[i - 1, j - 1] = True
 
         for j in range(0, grid.height):
             for i in range(0, grid.width):
                 if not mask[i, j]:
                     grid.set(i, j, None)
-
+        
         return mask
 
 class MiniGridEnv(gym.Env):


### PR DESCRIPTION
The logic for occluding portions of the grid hidden by cells with `cell.see_behind() = False` has some odd consequences; this very simple change to `Grid.process_vis` makes the behavior (imo) more intuitive.

[Archive of 26 before/after images](https://github.com/maximecb/gym-minigrid/files/4739043/minigrid_occlusion.zip)
example before:
![1_left_before](https://user-images.githubusercontent.com/4515230/83931109-c655fb00-a74f-11ea-942f-f7de4428e52b.png)
example after:
![1_left_after](https://user-images.githubusercontent.com/4515230/83931114-cf46cc80-a74f-11ea-9a00-28d9be6a915f.png)




