### PR TITLE
fix deprecated features in matplotlib >=3.2

### DIFF
--- a/gym_minigrid/window.py
+++ b/gym_minigrid/window.py
@@ -26,8 +26,10 @@ class Window:
         self.fig.canvas.set_window_title(title)
 
         # Turn off x/y axis numbering/ticks
-        self.ax.set_xticks([], [])
-        self.ax.set_yticks([], [])
+        self.ax.xaxis.set_ticks_position('none')
+        self.ax.yaxis.set_ticks_position('none')
+        _ = self.ax.set_xticklabels([])
+        _ = self.ax.set_yticklabels([])
 
         # Flag indicating the window was closed
         self.closed = False


### PR DESCRIPTION
`ax.set_xticks([], [])` and `ax.set_yticks([], [])` have been deprecated since Matplotlib 3.2. For now, it is only a warning message, but in the future it may become a full error.
+ unit test approved. 