### PR TITLE
agent_view_size added to main RoomGrid class and other four environments

### DIFF
--- a/gym_minigrid/envs/blockedunlockpickup.py
+++ b/gym_minigrid/envs/blockedunlockpickup.py
@@ -8,14 +8,15 @@ class BlockedUnlockPickup(RoomGrid):
     in another room
     """
 
-    def __init__(self, seed=None):
+    def __init__(self, seed=None, agent_view_size=7):
         room_size = 6
         super().__init__(
             num_rows=1,
             num_cols=2,
             room_size=room_size,
             max_steps=16*room_size**2,
-            seed=seed
+            seed=seed,
+            agent_view_size=agent_view_size
         )
 
     def _gen_grid(self, width, height):
@@ -46,7 +47,17 @@ class BlockedUnlockPickup(RoomGrid):
 
         return obs, reward, done, info
 
+
+class BlockedUnlockPickup1(BlockedUnlockPickup):
+    def __init__(self):
+        super().__init__(agent_view_size=3)
+
 register(
-    id='MiniGrid-BlockedUnlockPickup-v0',
+    id='MiniGrid-BlockedUnlockPickup-VU7-v0',
     entry_point='gym_minigrid.envs:BlockedUnlockPickup'
+)
+
+register(
+    id='MiniGrid-BlockedUnlockPickup-VU3-v1',
+    entry_point='gym_minigrid.envs:BlockedUnlockPickup1'
 )

--- a/gym_minigrid/envs/crossing.py
+++ b/gym_minigrid/envs/crossing.py
@@ -9,15 +9,24 @@ class CrossingEnv(MiniGridEnv):
     Environment with wall or lava obstacles, sparse reward.
     """
 
-    def __init__(self, size=9, num_crossings=1, obstacle_type=Lava, seed=None):
+    def __init__(
+        self,
+        size=9,
+        num_crossings=1,
+        obstacle_type=Lava,
+        seed=None,
+        agent_view_size=7
+    ):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
+
         super().__init__(
             grid_size=size,
             max_steps=4*size*size,
             # Set this to True for maximum speed
             see_through_walls=False,
-            seed=None
+            seed=None,
+            agent_view_size=agent_view_size
         )
 
     def _gen_grid(self, width, height):
@@ -98,6 +107,10 @@ class LavaCrossingS11N5Env(CrossingEnv):
     def __init__(self):
         super().__init__(size=11, num_crossings=5)
 
+class LavaCrossingS11N5VU5Env(CrossingEnv):
+    def __init__(self):
+        super().__init__(size=11, num_crossings=5, agent_view_size=5)
+
 register(
     id='MiniGrid-LavaCrossingS9N1-v0',
     entry_point='gym_minigrid.envs:LavaCrossingEnv'
@@ -118,6 +131,11 @@ register(
     entry_point='gym_minigrid.envs:LavaCrossingS11N5Env'
 )
 
+register(
+    id='MiniGrid-LavaCrossingS11N5VU5-v0',
+    entry_point='gym_minigrid.envs:LavaCrossingS11N5VU5Env'
+)
+
 class SimpleCrossingEnv(CrossingEnv):
     def __init__(self):
         super().__init__(size=9, num_crossings=1, obstacle_type=Wall)
@@ -133,6 +151,10 @@ class SimpleCrossingS9N3Env(CrossingEnv):
 class SimpleCrossingS11N5Env(CrossingEnv):
     def __init__(self):
         super().__init__(size=11, num_crossings=5, obstacle_type=Wall)
+
+class SimpleCrossingS11N5VU5Env(CrossingEnv):
+    def __init__(self):
+        super().__init__(size=11, num_crossings=5, obstacle_type=Wall, agent_view_size=7)
 
 register(
     id='MiniGrid-SimpleCrossingS9N1-v0',
@@ -152,4 +174,9 @@ register(
 register(
     id='MiniGrid-SimpleCrossingS11N5-v0',
     entry_point='gym_minigrid.envs:SimpleCrossingS11N5Env'
+)
+
+register(
+    id='MiniGrid-SimpleCrossingS11N5VU5-v0',
+    entry_point='gym_minigrid.envs:SimpleCrossingS11N5VU5Env'
 )

--- a/gym_minigrid/envs/distshift.py
+++ b/gym_minigrid/envs/distshift.py
@@ -12,7 +12,8 @@ class DistShiftEnv(MiniGridEnv):
         height=7,
         agent_start_pos=(1,1),
         agent_start_dir=0,
-        strip2_row=2
+        strip2_row=2,
+        agent_view_size=7
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -24,7 +25,8 @@ class DistShiftEnv(MiniGridEnv):
             height=height,
             max_steps=4*width*height,
             # Set this to True for maximum speed
-            see_through_walls=True
+            see_through_walls=True,
+            agent_view_size=agent_view_size
         )
 
     def _gen_grid(self, width, height):
@@ -59,6 +61,10 @@ class DistShift2(DistShiftEnv):
     def __init__(self):
         super().__init__(strip2_row=5)
 
+class DistShift3(DistShiftEnv):
+    def __init__(self):
+        super().__init__(strip2_row=5, agent_view_size=3)
+
 register(
     id='MiniGrid-DistShift1-v0',
     entry_point='gym_minigrid.envs:DistShift1'
@@ -67,4 +73,9 @@ register(
 register(
     id='MiniGrid-DistShift2-v0',
     entry_point='gym_minigrid.envs:DistShift2'
+)
+
+register(
+    id='MiniGrid-DistShift3-v0',
+    entry_point='gym_minigrid.envs:DistShift3'
 )

--- a/gym_minigrid/envs/doorkey.py
+++ b/gym_minigrid/envs/doorkey.py
@@ -6,10 +6,11 @@ class DoorKeyEnv(MiniGridEnv):
     Environment with a door and key, sparse reward
     """
 
-    def __init__(self, size=8):
+    def __init__(self, size=8, agent_view_size=7):
         super().__init__(
             grid_size=size,
-            max_steps=10*size*size
+            max_steps=10*size*size,
+            agent_view_size=agent_view_size
         )
 
     def _gen_grid(self, width, height):
@@ -55,6 +56,18 @@ class DoorKeyEnv16x16(DoorKeyEnv):
     def __init__(self):
         super().__init__(size=16)
 
+class DoorKeyEnv16x16VU5(DoorKeyEnv):
+    def __init__(self):
+        super().__init__(size=16, agent_view_size=5)
+
+class DoorKeyEnv16x16VU9(DoorKeyEnv):
+    def __init__(self):
+        super().__init__(size=16, agent_view_size=9)
+
+class DoorKeyEnv16x16VU11(DoorKeyEnv):
+    def __init__(self):
+        super().__init__(size=16, agent_view_size=11)
+
 register(
     id='MiniGrid-DoorKey-5x5-v0',
     entry_point='gym_minigrid.envs:DoorKeyEnv5x5'
@@ -73,4 +86,19 @@ register(
 register(
     id='MiniGrid-DoorKey-16x16-v0',
     entry_point='gym_minigrid.envs:DoorKeyEnv16x16'
+)
+
+register(
+    id='MiniGrid-DoorKey-16x16-VU5-v0',
+    entry_point='gym_minigrid.envs:DoorKeyEnv16x16VU5'
+)
+
+register(
+    id='MiniGrid-DoorKey-16x16-VU9-v0',
+    entry_point='gym_minigrid.envs:DoorKeyEnv16x16VU9'
+)
+
+register(
+    id='MiniGrid-DoorKey-16x16-VU11-v0',
+    entry_point='gym_minigrid.envs:DoorKeyEnv16x16VU11'
 )

--- a/gym_minigrid/envs/keycorridor.py
+++ b/gym_minigrid/envs/keycorridor.py
@@ -12,7 +12,8 @@ class KeyCorridor(RoomGrid):
         num_rows=3,
         obj_type="ball",
         room_size=6,
-        seed=None
+        seed=None,
+        agent_view_size=7
     ):
         self.obj_type = obj_type
 
@@ -21,6 +22,7 @@ class KeyCorridor(RoomGrid):
             num_rows=num_rows,
             max_steps=30*room_size**2,
             seed=seed,
+            agent_view_size=agent_view_size
         )
 
     def _gen_grid(self, width, height):

--- a/gym_minigrid/roomgrid.py
+++ b/gym_minigrid/roomgrid.py
@@ -72,7 +72,8 @@ class RoomGrid(MiniGridEnv):
         num_rows=3,
         num_cols=3,
         max_steps=100,
-        seed=0
+        seed=0,
+        agent_view_size=7
     ):
         assert room_size > 0
         assert room_size >= 3
@@ -93,7 +94,8 @@ class RoomGrid(MiniGridEnv):
             height=height,
             max_steps=max_steps,
             see_through_walls=False,
-            seed=seed
+            seed=seed,
+            agent_view_size=agent_view_size
         )
 
     def room_from_pos(self, x, y):


### PR DESCRIPTION
Pull request for the feature  #118 . Now RoomGrid support agent_view_size argument. Added new environments for crossing, distshift, doorkey and blockedunloackpickup with different agent_view_size parameter. Measuring performance of trained agent with various agent_view_size will be important while comparing its performance.