### PR TITLE
added argument agent_view_size for RoomGrid environment

### DIFF
--- a/gym_minigrid/roomgrid.py
+++ b/gym_minigrid/roomgrid.py
@@ -72,7 +72,8 @@ class RoomGrid(MiniGridEnv):
         num_rows=3,
         num_cols=3,
         max_steps=100,
-        seed=0
+        seed=0,
+        agent_view_size=7
     ):
         assert room_size > 0
         assert room_size >= 3
@@ -93,7 +94,8 @@ class RoomGrid(MiniGridEnv):
             height=height,
             max_steps=max_steps,
             see_through_walls=False,
-            seed=seed
+            seed=seed,
+            agent_view_size=agent_view_size
         )
 
     def room_from_pos(self, x, y):


### PR DESCRIPTION
Based on previous comments, I removed the example custom roomgrid environments in which agent_view_size was used. Now just basic change of added argument to RoomGrid class. Based on #118 